### PR TITLE
better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Crate to interact with SICD files."
-homepage = "https://github.com/holmesv3/sicd-rs"
+repository = "https://github.com/holmesv3/sicd-rs"
 readme = "README-crates.md"
 
 [dependencies]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it
See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field)
